### PR TITLE
Fix incorrect naming of loggerservice tests

### DIFF
--- a/Test/GTest/Scheduler/L4LoggerService/ConsoleLoggerGTest.cpp
+++ b/Test/GTest/Scheduler/L4LoggerService/ConsoleLoggerGTest.cpp
@@ -39,17 +39,17 @@
 /*---------------------------------------------------------------------------*/
 /*                           Method definitions                              */
 /*---------------------------------------------------------------------------*/
-TEST(Scheduler_L3Services_ConsoleLoggerGTest,TestConstructor) {
+TEST(Scheduler_L4LoggerService_ConsoleLoggerGTest,TestConstructor) {
     ConsoleLoggerTest target;
     ASSERT_TRUE(target.TestConstructor());
 }
 
-TEST(Scheduler_L3Services_ConsoleLoggerGTest,TestInitialise) {
+TEST(Scheduler_L4LoggerService_ConsoleLoggerGTest,TestInitialise) {
     ConsoleLoggerTest target;
     ASSERT_TRUE(target.TestInitialise());
 }
 
-TEST(Scheduler_L3Services_ConsoleLoggerGTest,TestConsumeLogMessage) {
+TEST(Scheduler_L4LoggerService_ConsoleLoggerGTest,TestConsumeLogMessage) {
     ConsoleLoggerTest target;
     ASSERT_TRUE(target.TestConsumeLogMessage());
 }

--- a/Test/GTest/Scheduler/L4LoggerService/LoggerConsumerIGTest.cpp
+++ b/Test/GTest/Scheduler/L4LoggerService/LoggerConsumerIGTest.cpp
@@ -38,32 +38,32 @@
 /*---------------------------------------------------------------------------*/
 /*                           Method definitions                              */
 /*---------------------------------------------------------------------------*/
-TEST(Scheduler_L3Services_LoggerConsumerIGTest,TestLoadPrintPreferences) {
+TEST(Scheduler_L4LoggerService_LoggerConsumerIGTest,TestLoadPrintPreferences) {
     LoggerConsumerITest target;
     ASSERT_TRUE(target.TestLoadPrintPreferences());
 }
 
-TEST(Scheduler_L3Services_LoggerConsumerIGTest,TestLoadPrintPreferences_SomeKeys) {
+TEST(Scheduler_L4LoggerService_LoggerConsumerIGTest,TestLoadPrintPreferences_SomeKeys) {
     LoggerConsumerITest target;
     ASSERT_TRUE(target.TestLoadPrintPreferences_SomeKeys());
 }
 
-TEST(Scheduler_L3Services_LoggerConsumerIGTest,TestLoadPrintPreferences_False_InvalidKey) {
+TEST(Scheduler_L4LoggerService_LoggerConsumerIGTest,TestLoadPrintPreferences_False_InvalidKey) {
     LoggerConsumerITest target;
     ASSERT_TRUE(target.TestLoadPrintPreferences_False_InvalidKey());
 }
 
-TEST(Scheduler_L3Services_LoggerConsumerIGTest,TestLoadPrintPreferences_False_TooLarge) {
+TEST(Scheduler_L4LoggerService_LoggerConsumerIGTest,TestLoadPrintPreferences_False_TooLarge) {
     LoggerConsumerITest target;
     ASSERT_TRUE(target.TestLoadPrintPreferences_False_TooLarge());
 }
 
-TEST(Scheduler_L3Services_LoggerConsumerIGTest,TestPrintToStream) {
+TEST(Scheduler_L4LoggerService_LoggerConsumerIGTest,TestPrintToStream) {
     LoggerConsumerITest target;
     ASSERT_TRUE(target.TestPrintToStream());
 }
 
-TEST(Scheduler_L3Services_LoggerConsumerIGTest,TestPrintToStream_WithKeys) {
+TEST(Scheduler_L4LoggerService_LoggerConsumerIGTest,TestPrintToStream_WithKeys) {
     LoggerConsumerITest target;
     ASSERT_TRUE(target.TestPrintToStream_WithKeys());
 }

--- a/Test/GTest/Scheduler/L4LoggerService/LoggerServiceGTest.cpp
+++ b/Test/GTest/Scheduler/L4LoggerService/LoggerServiceGTest.cpp
@@ -39,63 +39,63 @@
 /*---------------------------------------------------------------------------*/
 /*                           Method definitions                              */
 /*---------------------------------------------------------------------------*/
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestConstructor) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestConstructor) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestConstructor());
 }
 
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise_Defaults) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise_Defaults) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise_Defaults());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise_False_NoCPUs) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise_False_NoCPUs) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise_False_NoCPUs());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise_False_NoConsumers) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise_False_NoConsumers) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise_False_NoConsumers());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise_False_NotLoggerConsumerI) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise_False_NotLoggerConsumerI) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise_False_NotLoggerConsumerI());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise_False_StackSize_Zero) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise_False_StackSize_Zero) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise_False_StackSize_Zero());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestInitialise_False_NumberOfLoggerPages_Zero) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestInitialise_False_NumberOfLoggerPages_Zero) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestInitialise_False_NumberOfLoggerPages_Zero());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestGetCPUMask) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestGetCPUMask) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestGetCPUMask());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestGetNumberOfLogPages) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestGetNumberOfLogPages) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestGetNumberOfLogPages());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestGetStackSize) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestGetStackSize) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestGetStackSize());
 }
 
-TEST(Scheduler_L3Services_LoggerServiceGTest,TestExecute) {
+TEST(Scheduler_L4LoggerService_LoggerServiceGTest,TestExecute) {
     LoggerServiceTest target;
     ASSERT_TRUE(target.TestExecute());
 }


### PR DESCRIPTION
It's a trivial fix but it threw me off when looking for the GTest code - they're named incorrectly and just needs renaming to the correct directory.