### PR TITLE
Adding no-deprecated-declarations

### DIFF
--- a/MakeDefaults/MakeStdLibDefs.x86-linux
+++ b/MakeDefaults/MakeStdLibDefs.x86-linux
@@ -69,7 +69,7 @@ MARTe2_OPTIM ?=
 OPTIM = $(MARTe2_OPTIM)
 LFLAGS = -Wl,--no-as-needed -fPIC 
 #-O2 would force -fstrict-overflow and this breaks the compilation of the core (dereferencing type-punned pointer will break strict-aliasing rules)
-CFLAGS = -fPIC -Wall -std=c++98 -Werror -Wno-invalid-offsetof -Wno-unused-variable -fno-strict-aliasing
+CFLAGS = -fPIC -Wall -std=c++98 -Werror -Wno-invalid-offsetof -Wno-unused-variable -fno-strict-aliasing -Wno-deprecated-declarations
 CPPFLAGS = $(CFLAGS) -frtti 
 CFLAGSPEC= -DMARTe2_TEST_ENVIRONMENT=$(MARTe2_TEST_ENVIRONMENT) -DARCHITECTURE=$(ARCHITECTURE) -DENVIRONMENT=$(ENVIRONMENT) -DUSE_PTHREAD -pthread
 LIBRARIES =  -lm -lpthread -lrt -ldl


### PR DESCRIPTION
This is a temp fix for anyone using glibc 2.33 or below, between 2.31 and 2.34 this throws an error that ftime is deprecated, the real fix needs more work to use gettimeofday or clock_gettime which there is already a pull request for - this ones just easier to push through since it is a compiler flag and doesn't affect any code.