### PR TITLE
Fix statemachine start point

### DIFF
--- a/Source/Core/BareMetal/L6App/Loader.cpp
+++ b/Source/Core/BareMetal/L6App/Loader.cpp
@@ -137,6 +137,19 @@ ErrorManagement::ErrorType Loader::Configure(StructuredDataI &data, StreamI &con
     }
     if (ret.ErrorsCleared()) {
         ret.fatalError = !parsedConfiguration.MoveToRoot();
+        //We need items which exist outside the actual application to sometimes know the first state such as the statemachine
+        StreamString firstState;
+        data.Read("FirstState", firstState);
+        (void) firstState.Seek(0ull);
+        StreamString destination;
+        char8 term;
+        ret.fatalError = !firstState.GetToken(destination, ":", term);
+        for (uint32 i = 0; i < parsedConfiguration.GetNumberOfChildren(); i++){
+            parsedConfiguration.MoveToChild(i);
+            parsedConfiguration.Write("FirstState",destination.Buffer());
+            ret.fatalError = !parsedConfiguration.MoveToRoot();
+        }
+        ret.fatalError = !parsedConfiguration.MoveToRoot();
     }
     if (ret.ErrorsCleared()) {
         ret.initialisationError = !ObjectRegistryDatabase::Instance()->Initialise(parsedConfiguration);

--- a/Source/Core/Scheduler/L4StateMachine/StateMachine.cpp
+++ b/Source/Core/Scheduler/L4StateMachine/StateMachine.cpp
@@ -106,6 +106,8 @@ bool StateMachine::ExportData(StructuredDataI & data) {
 bool StateMachine::Initialise(StructuredDataI &data) {
     ErrorManagement::ErrorType err;
     err.parametersError = !ReferenceContainer::Initialise(data);
+    StreamString firstState;
+    data.Read("FirstState", firstState);
     bool ok = true;
     if (err.ErrorsCleared()) {
         //Loop on all the states
@@ -154,7 +156,7 @@ bool StateMachine::Initialise(StructuredDataI &data) {
     }
     //Install the event listeners for the first state
     if (err.ErrorsCleared()) {
-        currentState = Get(0u);
+        currentState = Find(firstState.Buffer());
         err.fatalError = !currentState.IsValid();
         if (!err.ErrorsCleared()) {
             REPORT_ERROR(ErrorManagement::FatalError, "No state at position zero was defined");

--- a/Source/Core/Scheduler/L4StateMachine/StateMachine.cpp
+++ b/Source/Core/Scheduler/L4StateMachine/StateMachine.cpp
@@ -117,6 +117,9 @@ bool StateMachine::Initialise(StructuredDataI &data) {
             if (state.IsValid()) {
                 uint32 j;
                 bool found = false;
+                if(StreamString(state->GetName()) == firstState){
+                    currentState = state;
+                }
                 for (j = 0u; (j < state->Size()) && (ok); j++) {
                     ReferenceT<StateMachineEvent> event = state->Get(j);
                     if (event.IsValid()) {
@@ -156,7 +159,6 @@ bool StateMachine::Initialise(StructuredDataI &data) {
     }
     //Install the event listeners for the first state
     if (err.ErrorsCleared()) {
-        currentState = Find(firstState.Buffer());
         err.fatalError = !currentState.IsValid();
         if (!err.ErrorsCleared()) {
             REPORT_ERROR(ErrorManagement::FatalError, "No state at position zero was defined");


### PR DESCRIPTION
This method might not be so MARTe-ish so let me know your thoughts but diving into the code as much as I could, I couldn't see any other way to get this information to children of the root configuration (I like to call them entities) which would relay data like the firstState to the StateMachine dynamically - i.e. the selected start state by the user parameters.

The only caveat to this method I can think of: All the documentation makes out you can have differing capitalisations on the state names in the applications but in the StateMachine you must have the state names capitalised, which is not actually true. So with this method, I've added a coupling of the two modules, I know I know, you want to avoid coupling of modules! So maybe we put an uppercase, uppercase on both, but then what if a user has STate1 and State1 in their application (also bonkers I know)?

I think this needs some consideration but from my side, our application could sometimes start in one state, or sometimes a different state. This is mainly within our CI's Q&A where we run configs in a dockerised environment prior to deployment.